### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the supplied Rake task:
 
 Next follows an example on how to configure your `Guardfile` with the Jasmine gem:
 
-    guard 'jasmine', :url => 'http://127.0.0.1:8888' do
+    guard 'jasmine', :jasmine_url => 'http://127.0.0.1:8888' do
       watch(%r{public/javascripts/(.+)\.js})                  { |m| "spec/javascripts/#{m[1]}_spec.js" }
       watch(%r{spec/javascripts/(.+)_spec\.js})               { |m| "spec/javascripts/#{m[1]}_spec.js" }
       watch(%r{spec/javascripts/support/jasmine\.yml})        { "spec/javascripts" }


### PR DESCRIPTION
For the "A note on Rails 2 and 3" section, the example Guardfile should use `:jasmine_url` instead of `:url` - fix attached.

Thanks for the great guard script!

I also run the jasmine server from Guard in Rails 3.0 - not sure if that would be interesting to include into the README, or if you're favoring only 3.1.  There's a slight hitch, since Guard doesn't guarantee that one guard process starts before another, so I have to make guard-jasmine wait until the jasmine server starts.  Gist here https://gist.github.com/1224382
