### PR TITLE
small fix so that we get a proper exit status to system/shell

### DIFF
--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -63,10 +63,11 @@ module Guard
         runner[:specdoc] = :always
 
         result = ::Guard::Jasmine::Runner.run(paths, runner)
-        Kernel.exit (result.first ? 0 : 1)
+        result = result.first ? 0 : 1
 
-      rescue Exception => e
-        ::Guard::UI.error e.message
+        #::Guard::UI.error e.message
+
+        Process.exit! result
       end
 
       desc 'version', 'Show the Guard::Jasmine version'


### PR DESCRIPTION
Awesome recent cli changes!  This is just a small tweak so that an exit status is properly returned to the system/shell (see the diff).  It's probably not exactly what you want as you might lose your ::Guard::UI.error message.  Anyhow, it looks like the problem is that Kernel.exit always raises so your rescue will always return a 0.  So making use of Process.exit! instead.
