### PR TITLE
Improve default Guardfile definition

### DIFF
--- a/lib/guard/jasmine/templates/Guardfile
+++ b/lib/guard/jasmine/templates/Guardfile
@@ -1,5 +1,5 @@
 guard 'jasmine' do
-  watch(%r{app/assets/javascripts/(.+)\.(js\.coffee|js)}) { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
-  watch(%r{spec/javascripts/(.+)_spec\.(js\.coffee|js)})  { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
-  watch(%r{spec/javascripts/spec\.(js\.coffee|js)})       { "spec/javascripts" }
+  watch(%r{app/assets/javascripts/(.+)\.(js\.coffee|js|coffee)$}) { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
+  watch(%r{spec/javascripts/(.+)_spec\.(js\.coffee|js|coffee)$})  { |m| puts m.inspect; "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
+  watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$})       { "spec/javascripts" }
 end


### PR DESCRIPTION
- Allow `js` files to also have `.coffee` extension only (apart from `.js.coffee` and `.js`)
- Take into account the possible tmp files (Vim, for example creates `.my_spec.coffee.swp` file) that should be ignored.

This basically adds `$` to make sure the file ends with the given extension (so that `.swp`, `.tmp` etc will be ignored) and `|coffee` to allow `.coffee` extensions. 
