### PR TITLE
Set the server's environment to test

### DIFF
--- a/lib/guard/jasmine/server.rb
+++ b/lib/guard/jasmine/server.rb
@@ -48,7 +48,10 @@ module Guard
 
           ::Guard::UI.info "Guard::Jasmine starts Rack test server on port #{ port }."
 
-          self.thread = Thread.new { Rack::Server.start(:config => 'config.ru', :Port => port, :AccessLog   => []) }
+          self.thread = Thread.new {
+            ENV['RAILS_ENV'] = 'test'
+            Rack::Server.start(:config => 'config.ru', :Port => port, :AccessLog   => [], :environment => 'test')
+          }
 
         rescue Exception => e
           ::Guard::UI.error "Cannot start Rack server: #{ e.message }"


### PR DESCRIPTION
By default, rack runs the server under the development environment.
This changes that behavior, to run it under test, which makes much more sense.

Rails doesn't takes the `:environment` parameter, so it requires to define the RAILS_ENV variable.
