### PR TITLE
Fix page always failing when iframes are being used

### DIFF
--- a/lib/guard/jasmine/phantomjs/run-jasmine.coffee
+++ b/lib/guard/jasmine/phantomjs/run-jasmine.coffee
@@ -234,6 +234,7 @@ page.onInitialized = ->
 # Open web page and run the Jasmine test runner
 #
 page.open url, (status) ->
+  page.onLoadFinished = ->
   if status isnt 'success'
     console.log JSON.stringify({ error: "Unable to access Jasmine specs at #{ url }" })
     phantom.exit()


### PR DESCRIPTION
When the page being loaded by run-jasmine.coffee (the main jasmine page) contains specs that load iframes, each of those iframes triggers the phantomjs page's onLoadFinished callback.  This can cause problems where the jasmine page loads successfully but some of the iframes that get generated by specs fail.  When this happens, you get the following error:

  Unable to access Jasmine specs at http://127.0.0.1:8888/

To fix this, the onLoadFinished handler for the page is reset after the first time its called.  This first status result is a guarantee that jasmine loaded successfully.  All further calls to that callback can be ignored.

This is potentially an issue that should be fixed in phantomjs, but we can at least get a workaround in guard-jasmine until then.
