### PR TITLE
don't need to call poll_for_exit when stopping server

### DIFF
--- a/lib/guard/jasmine/server.rb
+++ b/lib/guard/jasmine/server.rb
@@ -36,12 +36,7 @@ module Guard
         #
         def stop
           ::Guard::UI.info "Guard::Jasmine stops server."
-
-          begin
-            self.process.poll_for_exit(5)
-          rescue ChildProcess::TimeoutError
-            self.process.stop
-          end
+          self.process.stop(5)
         end
 
         private


### PR DESCRIPTION
Should just need to call stop on the process instead of calling poll_for_exit. All this does is wait for 5 seconds before calling the actual stop.
