### PR TITLE
Added clean option to be able to use different naming conventions

### DIFF
--- a/lib/guard/jasmine.rb
+++ b/lib/guard/jasmine.rb
@@ -30,6 +30,7 @@ module Guard
         :hide_success     => false,
         :all_on_start     => true,
         :keep_failed      => true,
+        :clean            => true,
         :all_after_pass   => true,
         :max_error_notify => 3,
         :specdoc          => :failure,
@@ -52,6 +53,7 @@ module Guard
     # @option options [Integer] :max_error_notify maximum error notifications to show
     # @option options [Boolean] :all_on_start run all suites on start
     # @option options [Boolean] :keep_failed keep failed suites and add them to the next run again
+    # @option options [Boolean] :clean clean the specs according to rails naming conventions
     # @option options [Boolean] :all_after_pass run all suites after a suite has passed again after failing
     # @option options [Symbol] :specdoc options for the specdoc output, either :always, :never or :failure
     # @option options [Symbol] :console options for the console.log output, either :always, :never or :failure
@@ -123,7 +125,8 @@ module Guard
     # @raise [:task_has_failed] when run_on_change has failed
     #
     def run_on_change(paths)
-      specs = Inspector.clean(options[:keep_failed] ? paths + self.last_failed_paths : paths)
+      specs = options[:keep_failed] ? paths + self.last_failed_paths : paths
+      specs = Inspector.clean(specs) if options[:clean]
       return false if specs.empty?
 
       passed, failed_specs = Runner.run(specs, options)


### PR DESCRIPTION
I'm using guard-jasmine outside of Rails and with a different naming convention
than in Rails. The specs are not in specs/javascript and are named differently.

In order to be able to use it anyway I added an option :clean, which defaults to true, 
to avoid having my specs removed by the clean call.

If :clean is set to false the Inspect.clean method will not be called.

I will be very happy if you like to integrate it with your code.

Kind regards
Anders
