### PR TITLE
Clean up Guardfile template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ Guard::Jasmine can be adapted to all kind of projects. Please read the
 
 ```ruby
 guard 'jasmine' do
-  watch(%r{app/assets/javascripts/(.+)\.(js\.coffee|js)}) { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
-  watch(%r{spec/javascripts/(.+)_spec\.(js\.coffee|js)})  { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
-  watch(%r{spec/javascripts/spec\.(js\.coffee|js)})       { "spec/javascripts" }
+  watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$})         { "spec/javascripts" }
+  watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
+  watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)$})  { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
 end
 ```
 

--- a/lib/guard/jasmine/templates/Guardfile
+++ b/lib/guard/jasmine/templates/Guardfile
@@ -1,5 +1,5 @@
 guard 'jasmine' do
-  watch(%r{app/assets/javascripts/(.+)\.(js\.coffee|js|coffee)$}) { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
-  watch(%r{spec/javascripts/(.+)_spec\.(js\.coffee|js|coffee)$})  { |m| puts m.inspect; "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
-  watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$})       { "spec/javascripts" }
+  watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$})         { "spec/javascripts" }
+  watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
+  watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)$})  { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
 end


### PR DESCRIPTION
- Remove block returning the tested path when the tested path equals the matched path.
- Have the test path related to a changed .js.coffee file be determined properly: `whatever.js.coffee` results in `whatever_spec.js.coffee` instead of `whatever.js_spec.coffee`.
