### PR TITLE
Format spec results on the CLI exactly like RSpec does.

### DIFF
--- a/lib/guard/jasmine/runner.rb
+++ b/lib/guard/jasmine/runner.rb
@@ -205,24 +205,30 @@ module Guard
         # @option options [Boolean] :hide_success hide success message notification
         #
         def notify_spec_result(result, options)
-          specs    = result['stats']['specs']
-          failures = result['stats']['failures']
-          time     = result['stats']['time']
-          plural   = failures == 1 ? '' : 's'
-
-          message = "#{ specs } specs, #{ failures } failure#{ plural }\nin #{ time } seconds"
-          passed  = failures == 0
-
+          specs           = result['stats']['specs']
+          failures        = result['stats']['failures']
+          time            = result['stats']['time']
+          specs_plural    = specs == 1    ? '' : 's'
+          failures_plural = failures == 1 ? '' : 's'
+          
+          Formatter.info("\nFinished in #{ time } seconds")
+          
+          message      = "#{ specs } spec#{ specs_plural }, #{ failures } failure#{ failures_plural }"
+          full_message = "#{ message }\nin #{ time } seconds"
+          passed       = failures == 0
+          
           if passed
             report_specdoc(result, passed, options) if options[:specdoc] == :always
             Formatter.success(message)
-            Formatter.notify(message, :title => 'Jasmine suite passed') if options[:notification] && !options[:hide_success]
+            Formatter.notify(full_message, :title => 'Jasmine suite passed') if options[:notification] && !options[:hide_success]
           else
             report_specdoc(result, passed, options) if options[:specdoc] != :never
             Formatter.error(message)
             notify_errors(result, options)
-            Formatter.notify(message, :title => 'Jasmine suite failed', :image => :failed, :priority => 2) if options[:notification]
+            Formatter.notify(full_message, :title => 'Jasmine suite failed', :image => :failed, :priority => 2) if options[:notification]
           end
+          
+          Formatter.info("Done.\n")
         end
 
         # Specdoc like formatting of the result.

--- a/spec/guard/jasmine/runner_spec.rb
+++ b/spec/guard/jasmine/runner_spec.rb
@@ -218,7 +218,7 @@ describe Guard::Jasmine::Runner do
           formatter.should_not_receive(:suite_name)
           formatter.should_not_receive(:spec_failed)
           formatter.should_receive(:error).with(
-              "3 specs, 2 failures\nin 0.007 seconds"
+              "3 specs, 2 failures"
           )
           runner.run(['spec/javascripts/x/b.js.coffee'], defaults.merge({ :specdoc => :never }))
         end
@@ -416,7 +416,7 @@ describe Guard::Jasmine::Runner do
               '    ✔ Success nested test tests something'
           )
           formatter.should_receive(:success).with(
-              "3 specs, 0 failures\nin 0.009 seconds"
+              "3 specs, 0 failures"
           )
           runner.run(['spec/javascripts/x/t.js'], defaults.merge({ :specdoc => :always }))
         end
@@ -456,7 +456,7 @@ describe Guard::Jasmine::Runner do
           )
           formatter.should_not_receive(:suite_name)
           formatter.should_receive(:success).with(
-              "3 specs, 0 failures\nin 0.009 seconds"
+              "3 specs, 0 failures"
           )
           runner.run(['spec/javascripts/x/t.js'], defaults.merge({ :specdoc => :never }))
         end


### PR DESCRIPTION
> Finished in x.xxx seconds
> x specs, x failures
> Done.

instead of

> x specs, x failures
> in x.xxx seconds
