### PR TITLE
Command line works but rake task does nothing

### DIFF
--- a/lib/guard/jasmine/task.rb
+++ b/lib/guard/jasmine/task.rb
@@ -32,7 +32,7 @@ module Guard
 
       namespace :guard do
         desc 'Run all Jasmine specs'
-        task(name) do
+        new_task = task(name) do
           begin
             ::Guard::Jasmine::CLI.start(options.split)
 
@@ -45,6 +45,8 @@ module Guard
             end
           end
         end
+
+        new_task.execute
       end
     end
 


### PR DESCRIPTION
I'm using the following rake task

``` ruby
task 'jasminetest' do
  require 'guard/jasmine/task'
  Guard::JasmineTask.new
end
```

If I just run 'guard-jasmine' I get a bunch of passing/failed tests but by running 'rake jasminetest' I get nothing outputted. Walking through the code it looks like the block that creates a task doesn't actually run anything. Calling execute on the task causes it to fire up and run the tasks though.

I added code in the pull request that does this. I'm not sure this is the right behavior but it does run the tests.

Is this supposed to automatically get executed or am I missing something from my rake task? I went right from the readme.
