### PR TITLE
Does nothing if the spec file does not exist

### DIFF
--- a/lib/guard/jasmine/runner.rb
+++ b/lib/guard/jasmine/runner.rb
@@ -34,7 +34,7 @@ module Guard
           notify_start_message(paths, options)
 
           results = paths.inject([]) do |results, file|
-            results << evaluate_response(run_jasmine_spec(file, options), file, options)
+            results << evaluate_response(run_jasmine_spec(file, options), file, options) if File.exist?(file)
 
             results
           end.compact

--- a/spec/guard/jasmine/runner_spec.rb
+++ b/spec/guard/jasmine/runner_spec.rb
@@ -146,12 +146,21 @@ describe Guard::Jasmine::Runner do
   describe '#run' do
     before do
       File.stub(:foreach).and_yield 'describe "ErrorTest", ->'
+      File.stub(:exist?).and_return(true)
       IO.stub(:popen).and_return StringIO.new(phantomjs_error_response)
     end
 
     context 'when passed an empty paths list' do
       it 'returns false' do
         runner.run([]).should eql [false, []]
+      end
+    end
+
+    context 'when the spec file does not exist' do
+      it 'does nothing' do
+        File.stub(:exist?).with('spec/javascripts').and_return(false)
+        runner.should_not_receive(:evaluate_response)
+        runner.run(['spec/javascripts'])
       end
     end
 


### PR DESCRIPTION
We should do nothing if the spec file does not exist in the file system. This fix related to issues 59.
