### PR TITLE
Respect the RAILS_ENV environment variable

### DIFF
--- a/lib/guard/jasmine.rb
+++ b/lib/guard/jasmine.rb
@@ -22,7 +22,7 @@ module Guard
 
     DEFAULT_OPTIONS = {
         :server           => :auto,
-        :server_env       => 'development',
+        :server_env       => ENV['RAILS_ENV'] || 'development',
         :port             => 8888,
         :jasmine_url      => 'http://localhost:8888/jasmine',
         :timeout          => 10000,

--- a/spec/guard/jasmine/cli_spec.rb
+++ b/spec/guard/jasmine/cli_spec.rb
@@ -67,6 +67,13 @@ describe Guard::Jasmine::CLI do
           cli.start(['spec', '--server_env', 'development'])
         end
 
+        it 'respects the RAILS_ENV environment variable' do
+          ENV['RAILS_ENV'] = "test"
+          runner.should_receive(:run).with(anything(), hash_including(:server_env => 'test')).and_return [true, []]
+          cli.start(['spec'])
+          ENV['RAILS_ENV'] = nil
+        end
+
         context 'for a valid console option' do
           it 'sets the console option' do
             runner.should_receive(:run).with(anything(), hash_including(:console => :always)).and_return [true, []]


### PR DESCRIPTION
until now if you want the tests to run in an environment different to development you must manually configure, which is quite painful in CI.
