### PR TITLE
Guard::Jasmine::CLI: making specdoc an option instead of forced to :always

### DIFF
--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -69,6 +69,11 @@ module Guard
                     :default => 'failure',
                     :desc => 'Whether to show errors in the spec runner, either `always`, `never` or `failure`'
 
+      method_option :specdoc,
+                    :type => :string,
+                    :default => :always,
+                    :desc => 'Whether to show successes in the spec runner, either `always`, `never` or `failure`'
+
       method_option :server_env,
                     :type => :string,
                     :aliases => '-e',
@@ -98,6 +103,7 @@ module Guard
         runner[:spec_dir] = options.spec_dir
         runner[:console] = [:always, :never, :failure].include?(options.console.to_sym) ? options.console.to_sym : :failure
         runner[:errors] = [:always, :never, :failure].include?(options.errors.to_sym) ? options.errors.to_sym : :failure
+        runner[:specdoc] = [:always, :never, :failure].include?(options.specdoc.to_sym) ? options.specdoc.to_sym : :always
         runner[:server] = options.server.to_sym
         runner[:focus] = options.focus
 
@@ -106,7 +112,6 @@ module Guard
         runner[:hide_success] = true
 
         runner[:max_error_notify] = 0
-        runner[:specdoc] = :always
 
         if CLI.phantomjs_bin_valid?(runner[:phantomjs_bin])
           ::Guard::Jasmine::Server.start(runner[:server], runner[:port], runner[:server_env], runner[:spec_dir]) unless runner[:server] == :none

--- a/spec/guard/jasmine/cli_spec.rb
+++ b/spec/guard/jasmine/cli_spec.rb
@@ -153,6 +153,17 @@ describe Guard::Jasmine::CLI do
           runner.should_receive(:run).with(anything(), hash_including(:server_env => 'test')).and_return [true, []]
           cli.start(['spec'])
         end
+
+        it 'sets the specdoc to always by default' do
+          runner.should_receive(:run).with(anything(), hash_including(:specdoc => :always)).and_return [true, []]
+          cli.start(['spec'])
+        end
+
+        it 'sets the specdoc to failure' do
+          runner.should_receive(:run).with(anything(), hash_including(:specdoc => :failure)).and_return [true, []]
+          cli.start(['spec', '--specdoc', 'failure'])
+        end
+
       end
     end
 
@@ -169,11 +180,6 @@ describe Guard::Jasmine::CLI do
 
       it 'sets the maximum error notifications to none' do
         runner.should_receive(:run).with(anything(), hash_including(:max_error_notify => 0)).and_return [true, []]
-        cli.start(['spec'])
-      end
-
-      it 'sets the specdoc to always' do
-        runner.should_receive(:run).with(anything(), hash_including(:specdoc => :always)).and_return [true, []]
         cli.start(['spec'])
       end
     end


### PR DESCRIPTION
This means we can optionally get quiet spec output from with the rake-task like this:

```
  require 'guard/jasmine/task'
  Guard::JasmineTask.new do |task|
    task.options = '--specdoc failure'
  end
```

Now only if a spec fails will the output be verbose. Interested in including this?
