### PR TITLE
Guardfile: watch js.erb assets

### DIFF
--- a/lib/guard/jasmine/templates/Guardfile
+++ b/lib/guard/jasmine/templates/Guardfile
@@ -1,5 +1,5 @@
 guard 'jasmine' do
   watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$})         { "spec/javascripts" }
   watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
-  watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)$})  { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
+  watch(%r{app/assets/javascripts/(.+?)\.(js|coffee)})  { |m| "spec/javascripts/#{m[1]}_spec.#{m[2]}" }
 end


### PR DESCRIPTION
Some of my files in the app/assets/javascripts directory use the asset pipeline to embed things like paths, urls and config vars, but the default Guardfile only watches assets that end in ".js" or ".coffee". 

This patch updates the Guardfile to watch ".js*" or ".coffee*", so ".js.erb" files will trigger guard-jasmine.
