### PR TITLE
Make sure the server process dies on error

### DIFF
--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -122,6 +122,7 @@ module Guard
 
             Process.exit result.first ? 0 : 1
           else
+            ::Guard::Jasmine::Server.stop
             Process.exit 2
           end
 

--- a/spec/guard/jasmine/cli_spec.rb
+++ b/spec/guard/jasmine/cli_spec.rb
@@ -204,6 +204,11 @@ describe Guard::Jasmine::CLI do
         Process.should_receive(:exit).with(2)
         cli.start(['spec'])
       end
+
+      it 'attemps to stop the server process, that may be running' do
+        server.should_receive(:stop)
+        cli.start(['spec'])
+      end
     end
 
     context 'with a runner exception' do


### PR DESCRIPTION
It's possible that a server process is spawned and it is alive, even if runner_available? returns false. This change calls Server.stop to make sure that the server won't hang around forever.

This caused an issue with our CI server, where one failed test run left a child process that held the listening socket, and further test runs would fail.

I also fixed a small typo in the 'without the runner available' spec.
