### PR TITLE
Add Puma to the list of rack-compatible servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Puma as a rack-compatible server
+
 ## 1.10.1 - November 19, 2012
 
 - [Issue #90](https://github.com/netzpirat/guard-jasmine/issues/90): Fix wrong port in the default Jasmine url.

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ The server options configures the server environment that is needed to run Guard
 
 ```ruby
 :server => :jasmine_gem                       # Jasmine server to use, either :auto, :none,
-                                              # :webrick, :mongrel, :thin, :unicorn, :jasmine_gem
+                                              # :webrick, :mongrel, :thin, :unicorn, :jasmine_gem, :puma
                                               # default: :auto
 
 :server_env => :test                          # Jasmine server Rails environment to set,
@@ -361,7 +361,7 @@ The server options configures the server environment that is needed to run Guard
 :timeout => 20                                # The time in seconds to wait for the spec runner to finish.
                                               # default: 10
 
-:rackup_config => 'spec/dummy/config.ru'      # Path to rackup config file (i.e. for webrick, mongrel, thin, unicorn).
+:rackup_config => 'spec/dummy/config.ru'      # Path to rackup config file (i.e. for webrick, mongrel, thin, unicorn, puma).
                                               # default: ./config.ru
                                               # This option is useful when using guard-jasmine in a mountable engine
                                               # and the config.ru is within the dummy app
@@ -537,7 +537,7 @@ Usage:
   guard-jasmine spec
 
 Options:
-  -s, [--server=SERVER]          # Server to start, either `auto`, `webrick`, `mongrel`, `thin`,
+  -s, [--server=SERVER]          # Server to start, either `auto`, `webrick`, `mongrel`, `thin`, `puma`
                                  # `unicorn`, `jasmine_gem` or `none`
                                  # Default: auto
   -p, [--port=N]                 # Server port to use

--- a/lib/guard/jasmine/server.rb
+++ b/lib/guard/jasmine/server.rb
@@ -32,7 +32,7 @@ module Guard
           timeout = options[:server_timeout]
 
           case server
-          when :webrick, :mongrel, :thin
+          when :webrick, :mongrel, :thin, :puma
             start_rack_server(server, port, options)
           when :unicorn
             start_unicorn_server(port, options)

--- a/spec/guard/jasmine/server_spec.rb
+++ b/spec/guard/jasmine/server_spec.rb
@@ -163,6 +163,27 @@ describe Guard::Jasmine::Server do
       end
     end
 
+    context 'with the :puma strategy' do
+      let(:options) do
+        defaults.merge({ :server => :puma })
+      end
+
+      it 'does not auto detect a server' do
+        server.should_not_receive(:detect_server)
+        server.start(options)
+      end
+
+      it 'does wait for the server' do
+        server.should_receive(:wait_for_server)
+        server.start(options)
+      end
+
+      it 'starts a :puma rack server' do
+        server.should_receive(:start_rack_server).with(:puma, 8888, options)
+        server.start(options)
+      end
+    end
+
     context 'with the :mongrel strategy' do
       let(:options) do
         defaults.merge({ :server => :mongrel })


### PR DESCRIPTION
As Puma (http://puma.io) is a rack-compatible server, it would be handy to add it to the list of servers that can be `rackup`'d natively.
