### PR TITLE
Add --coverage_html support to cli

### DIFF
--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -97,10 +97,15 @@ module Guard
                     :default => false,
                     :desc    => 'Whether to enable the coverage support or not'
                     
-       method_option :coverage_html,
+      method_option :coverage_html,
                     :type    => :boolean,
                     :default => false,
                     :desc    => 'Whether to generate html coverage report.  Implies --coverage'
+
+      method_option :coverage_summary,
+                    :type    => :boolean,
+                    :default => false,
+                    :desc    => 'Whether to generate html coverage summary.  Implies --coverage'
 
       method_option :statements_threshold,
                     :type    => :numeric,
@@ -144,8 +149,9 @@ module Guard
         runner_options[:errors]               = [:always, :never, :failure].include?(options.errors.to_sym) ? options.errors.to_sym : :failure
         runner_options[:specdoc]              = [:always, :never, :failure].include?(options.specdoc.to_sym) ? options.specdoc.to_sym : :always
         runner_options[:focus]                = options.focus
-        runner_options[:coverage]             = options.coverage || options.coverage_html
+        runner_options[:coverage]             = options.coverage || options.coverage_html || options.coverage_summary
         runner_options[:coverage_html]        = options.coverage_html
+        runner_options[:coverage_summary]     = options.coverage_summary
         runner_options[:statements_threshold] = options.statements_threshold
         runner_options[:functions_threshold]  = options.functions_threshold
         runner_options[:branches_threshold]   = options.branches_threshold


### PR DESCRIPTION
Unless I'm missing something (I'm new to guard-jasmine), there was no way to get html coverage when running shell-level guard-jasmine outside of guard.  So I added  --coverage_html to the CLI options, and passed it along.

The only extra liberty I took is to have --coverage_html imply --coverage.  Seems reasonable to me that 
   $ guard-jasmine --coverage_html
should work, rather than needing
   $ guard-jasmine --coverage --coverage_html

Thanks much for putting all this together!
