### PR TITLE
Bug fix: coverage hangs for large files

### DIFF
--- a/lib/guard/jasmine/coverage.rb
+++ b/lib/guard/jasmine/coverage.rb
@@ -26,16 +26,12 @@ class JasmineCoverage < Tilt::Template
 
       File.write input, data
 
-      r, w = IO.pipe
-      proc = ChildProcess.build(JasmineCoverage.coverage_bin, 'instrument', '--embed-source', input)
-      proc.io.stdout = proc.io.stderr = w
-      proc.start
-      proc.wait
-      w.close
+      result = %x[#{JasmineCoverage.coverage_bin} instrument --embed-source #{input.shellescape}]
 
-      raise "Could not generate coverage instrumented file for #{ file }" unless proc.exit_code == 0
+      raise "Could not generate coverage instrumented file for #{ file }" unless $?.exitstatus == 0
 
-      r.read.gsub input, file
+      result.gsub input, file
+
     end
   end
 


### PR DESCRIPTION
The code that used IO.pipe & ChildProcess to run istanbul was waiting for the process to finish before reading the result.  With a file whose instrumentation is large enough to exceed the system IO buffer size, the istanbul process would block and we'd have deadlock. 
 Rather than fixing that using the appropriate nonblocking reading, just switched to %x[]
