### PR TITLE
Configured Guardfile to watch for changes in fixtures directory

### DIFF
--- a/lib/guard/jasmine/templates/Guardfile
+++ b/lib/guard/jasmine/templates/Guardfile
@@ -1,5 +1,6 @@
 guard :jasmine do
   watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$}) { 'spec/javascripts' }
   watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
+  watch(%r{spec/javascripts/fixtures/.+$})
   watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) { |m| "spec/javascripts/#{ m[1] }_spec.#{ m[2] }" }
 end


### PR DESCRIPTION
I think the use of a fixtures directory is common enough that it should be covered by the default Guardfile.
