### PR TITLE
Actually respect the server timeout option.

### DIFF
--- a/lib/guard/jasmine/util.rb
+++ b/lib/guard/jasmine/util.rb
@@ -24,20 +24,20 @@ module Guard
         begin
           ::Guard::Jasmine::Formatter.info "Waiting for Jasmine test runner at #{ url }"
 
-          Timeout::timeout(options[:server_timeout]) do
-            Net::HTTP.start(url.host, url.port) do |http|
-              response  = http.request(Net::HTTP::Get.new(url.path))
-              available = response.code.to_i == 200
+          http = Net::HTTP.new(url.host, url.port)
+          http.read_timeout = options[:server_timeout]
+          http.start do
+            response  = http.request(Net::HTTP::Get.new(url.path))
+            available = response.code.to_i == 200
 
-              unless available
-                ::Guard::Jasmine::Formatter.error "Jasmine test runner failed with status #{ response.code }"
-                if response.body
-                  ::Guard::Jasmine::Formatter.error 'Please open the Jasmine runner in your browser for more information.'
-                end
+            unless available
+              ::Guard::Jasmine::Formatter.error "Jasmine test runner failed with status #{ response.code }"
+              if response.body
+                ::Guard::Jasmine::Formatter.error 'Please open the Jasmine runner in your browser for more information.'
               end
-
-              available
             end
+
+            available
           end
 
         rescue Timeout::Error => e


### PR DESCRIPTION
The problem with the way it was structured before is that Net::HTTP instances have their own read timeout of 60s. If you configured server timeout to be longer than that then the inner timeout will fire first and be caught by the rescue handler for `Timeout::Error`, which assumes that the configured server timeout has elapsed.

I ran into this with an app that, for some reason, is taking longer than 60s to respond (slow CI machine?). I had configured both timeout and server timeout to be 600,000s and have a global timeout on the CI server that will just kill anything that takes too long.
