### PR TITLE
Only log console messages if there's a spec in progress.

### DIFF
--- a/lib/guard/jasmine/phantomjs/guard-jasmine.coffee
+++ b/lib/guard/jasmine/phantomjs/guard-jasmine.coffee
@@ -24,7 +24,7 @@ errors = {}
 # Catch JavaScript errors
 #
 page.onError = (msg, trace) ->
-  if currentSpecId
+  if currentSpecId > -1
     errors[currentSpecId] ||= []
     errors[currentSpecId].push({ msg: msg, trace: trace })
 
@@ -41,7 +41,7 @@ page.onConsoleMessage = (msg, line, source) ->
     currentSpecId = Number(RegExp.$1)
     logs[currentSpecId] = []
 
-  else
+  else if currentSpecId > -1
     logs[currentSpecId].push(msg)
 
 # Initialize the page before the JavaScript is run.

--- a/lib/guard/jasmine/phantomjs/guard-jasmine.js
+++ b/lib/guard/jasmine/phantomjs/guard-jasmine.js
@@ -22,7 +22,7 @@
   errors = {};
 
   page.onError = function(msg, trace) {
-    if (currentSpecId) {
+    if (currentSpecId > -1) {
       errors[currentSpecId] || (errors[currentSpecId] = []);
       return errors[currentSpecId].push({
         msg: msg,
@@ -44,7 +44,7 @@
     } else if (/^SPEC_START: (\d+)$/.test(msg)) {
       currentSpecId = Number(RegExp.$1);
       return logs[currentSpecId] = [];
-    } else {
+    } else if (currentSpecId > -1) {
       return logs[currentSpecId].push(msg);
     }
   };


### PR DESCRIPTION
Frameworks that logged to the console during initialization (eg EmberJS) were causing an error because logs[-1] was undefined. For bonus points, Ember helpfully swallowed this error in development and carried on, meaning that all the tests would mysteriously fail instead...

It might be useful to start logging these 'global' log messages too and communicating them back to the runner, but at least this gets my tests running again. :)
