### PR TITLE
Fix #117 add dependency of tilt gem

### DIFF
--- a/guard-jasmine.gemspec
+++ b/guard-jasmine.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json'
   s.add_dependency 'childprocess'
   s.add_dependency 'thor'
+  s.add_dependency 'tilt'
 
   s.add_development_dependency 'bundler'
 


### PR DESCRIPTION
I found that it is because of guard/jasmine/coverage requires tilt,
but gemspec not includes dependency of tilt.

please test it on new directory only includes Gemfile

``` ruby
gem 'guard-jasmine', :git => 'git://github.com/masarakki/guard-jasmine', :branch => 'add_dependency_of_tilt'
```

and run

```
 bundle exec guard init
```
