### PR TITLE
Unconventional output when executed via rake or guard-jasmine

### DIFF
--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -170,6 +170,8 @@ module Guard
         runner_options[:hide_success]             = true
         runner_options[:max_error_notify]         = 0
 
+        ::Guard::UI.options = ::Guard::UI.options.merge({ :template => ':message' })
+
         paths = [runner_options[:spec_dir]] if paths.empty?
 
         if CLI.phantomjs_bin_valid?(runner_options[:phantomjs_bin])


### PR DESCRIPTION
This is a very minor issue, and possibly, more of a question than anything serious.

The output from guard-jasmine is unconventional when run via the command line (`guard-jasmine`) or the rake task. By unconventional, I'm specifically referring to the timestamps and INFO log level.

```
% guard-jasmine
08:49:44 - INFO - Guard::Jasmine starts Unicorn spec server on port 51640 in test environment (coverage off).
08:49:45 - INFO - Waiting for Jasmine test runner at http://localhost:51640/jasmine
08:49:47 - INFO - Run all Jasmine suites
08:49:47 - INFO - Run Jasmine suite at http://localhost:51640/jasmine
08:49:49 - INFO - Finished in 0.012 seconds
08:49:49 - INFO - Foo
08:49:49 - INFO -   ✔ it is not bar
08:49:49 - INFO - Bar
08:49:49 - INFO -   ✔ it is not foo
08:49:49 - INFO - 2 specs, 0 failures
08:49:49 - INFO - Done.
08:49:49 - INFO - Guard::Jasmine stops server.
```

That output style is consistent with what you see when running guard, but it stands out a bit outside of guard. To be clear, I would expect to see:

```
% guard-jasmine
Guard::Jasmine starts Unicorn spec server on port 51640 in test environment (coverage off).
Waiting for Jasmine test runner at http://localhost:51640/jasmine
Run all Jasmine suites
Run Jasmine suite at http://localhost:51640/jasmine
Finished in 0.012 seconds
Foo
 ✔ it is not bar
Bar
 ✔ it is not foo
2 specs, 0 failures
Done.
Guard::Jasmine stops server.
```

In my experience, most guard plugins don't include the timestamps and log level in the output of commands they execute. For example, `guard-rspec` doesn't add timestamps to the output of rspec.

I admit it's a cosmetic thing at worst. Regardless, are you opposed to a) dropping the timestamps and log level or b) conditionally displaying them only when run from within guard? If not, I'll try to put together a pull request for you.

Thanks!
Christian
