### PR TITLE
Allows Jasmine to be loaded asynchronously inside guard-jasmine

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,9 +643,9 @@ Options:
                                         # Default: spec/javascripts
   -u, [--url=URL]                       # The url of the Jasmine test runner_options
                                         # Default: nil
-  -t, [--timeout=N]                     # The maximum time in milliseconds to wait for the spec
+  -t, [--timeout=N]                     # The maximum time in seconds to wait for the spec
                                         # runner to finish
-                                        # Default: 10000
+                                        # Default: 10
       [--console=CONSOLE]               # Whether to show console.log statements in the spec runner,
                                         # either `always`, `never` or `failure`
                                         # Default: failure

--- a/lib/guard/jasmine/phantomjs/guard-jasmine.js
+++ b/lib/guard/jasmine/phantomjs/guard-jasmine.js
@@ -1,11 +1,11 @@
 (function() {
-  var currentSpecId, errors, logs, options, page, specsReady, waitFor;
+  var currentSpecId, errors, jasmineAvailable, jasmineMissing, jasmineReady, logs, options, page, specsDone, specsReady, specsTimedout, waitFor;
 
   phantom.injectJs('lib/result.js');
 
   options = {
     url: phantom.args[0] || 'http://127.0.0.1:3000/jasmine',
-    timeout: parseInt(phantom.args[1] || 5000),
+    timeout: parseInt(phantom.args[1] || 10000),
     specdoc: phantom.args[2] || 'failure',
     focus: /true/i.test(phantom.args[3]),
     console: phantom.args[4] || 'failure',
@@ -32,6 +32,7 @@
 
   page.onConsoleMessage = function(msg, line, source) {
     var result;
+
     if (/^RUNNER_END$/.test(msg)) {
       result = page.evaluate(function() {
         return window.reporter.runnerResult;
@@ -53,15 +54,17 @@
     page.injectJs('lib/reporter.js');
     return page.evaluate(function() {
       return window.onload = function() {
+        window.onload = null;
         window.resultReceived = false;
         window.reporter = new ConsoleReporter();
-        return jasmine.getEnv().addReporter(window.reporter);
+        if (window.jasmine) {
+          return jasmine.getEnv().addReporter(window.reporter);
+        }
       };
     });
   };
 
   page.open(options.url, function(status) {
-    var done, error, runnerAvailable, text;
     page.onLoadFinished = function() {};
     if (status !== 'success') {
       console.log(JSON.stringify({
@@ -69,33 +72,37 @@
       }));
       return phantom.exit();
     } else {
-      runnerAvailable = page.evaluate(function() {
-        return window.jasmine;
-      });
-      if (runnerAvailable) {
-        done = function() {
-          return phantom.exit();
-        };
-        return waitFor(specsReady, done, options.timeout);
-      } else {
-        text = page.evaluate(function() {
-          var _ref;
-          return (_ref = document.getElementsByTagName('body')[0]) != null ? _ref.innerText : void 0;
-        });
-        if (text) {
-          error = "The Jasmine reporter is not available!\n\n" + text;
-          console.log(JSON.stringify({
-            error: error
-          }));
-        } else {
-          console.log(JSON.stringify({
-            error: 'The Jasmine reporter is not available!'
-          }));
-        }
-        return phantom.exit(1);
-      }
+      return waitFor(jasmineReady, jasmineAvailable, options.timeout, jasmineMissing);
     }
   });
+
+  jasmineReady = function() {
+    return page.evaluate(function() {
+      return window.jasmine;
+    });
+  };
+
+  jasmineAvailable = function() {
+    return waitFor(specsReady, specsDone, options.timeout, specsTimedout);
+  };
+
+  jasmineMissing = function() {
+    var error, text;
+
+    text = page.evaluate(function() {
+      return document.getElementsByTagName('body')[0].innerText;
+    });
+    if (text) {
+      error = "The Jasmine reporter is not available!\n\n" + text;
+      return console.log(JSON.stringify({
+        error: error
+      }));
+    } else {
+      return console.log(JSON.stringify({
+        error: 'The Jasmine reporter is not available!'
+      }));
+    }
+  };
 
   specsReady = function() {
     return page.evaluate(function() {
@@ -103,37 +110,46 @@
     });
   };
 
-  waitFor = function(test, ready, timeout) {
-    var condition, interval, start, wait;
-    if (timeout == null) {
-      timeout = 5000;
+  specsTimedout = function() {
+    var error, text;
+
+    text = page.evaluate(function() {
+      return document.getElementsByTagName('body')[0].innerText;
+    });
+    if (text) {
+      error = "Timeout waiting for the Jasmine test results!\n\n" + text;
+      return console.log(JSON.stringify({
+        error: error
+      }));
+    } else {
+      return console.log(JSON.stringify({
+        error: 'Timeout for the Jasmine test results!'
+      }));
     }
-    start = new Date().getTime();
+  };
+
+  specsDone = function() {
+    return phantom.exit();
+  };
+
+  waitFor = function(test, ready, timeout, timeoutFunction) {
+    var condition, interval, start, wait;
+
+    if (timeout == null) {
+      timeout = 10000;
+    }
+    start = Date.now();
     condition = false;
     wait = function() {
-      var error, text;
-      if ((new Date().getTime() - start < timeout) && !condition) {
+      if ((Date.now() - start < timeout) && !condition) {
         return condition = test();
       } else {
-        if (!condition) {
-          text = page.evaluate(function() {
-            var _ref;
-            return (_ref = document.getElementsByTagName('body')[0]) != null ? _ref.innerText : void 0;
-          });
-          if (text) {
-            error = "Timeout waiting for the Jasmine test results!\n\n" + text;
-            console.log(JSON.stringify({
-              error: error
-            }));
-          } else {
-            console.log(JSON.stringify({
-              error: 'Timeout waiting for the Jasmine test results!'
-            }));
-          }
-          return phantom.exit(1);
+        clearInterval(interval);
+        if (condition) {
+          return ready();
         } else {
-          ready();
-          return clearInterval(interval);
+          timeoutFunction();
+          return phantom.exit(1);
         }
       }
     };


### PR DESCRIPTION
In order to use RequireJS and guard-jasmine, the check for 'window.jasmine' needs also to have a wait-loop.
Also small fixes in the Readme file (seconds, not milliseconds)
