### PR TITLE
Fix detect a directory as the phantomjs executable

### DIFF
--- a/lib/guard/jasmine/util.rb
+++ b/lib/guard/jasmine/util.rb
@@ -110,7 +110,7 @@ module Guard
         ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
           exts.each do |ext|
             exe = "#{ path }/#{ cmd }#{ ext }"
-            return exe if File.executable?(exe)
+            return exe if File.file?(exe) && File.executable?(exe)
           end
         end
 


### PR DESCRIPTION
`File.executable?(exe)` will return `true` for directories. This patch ensures that only files are selected.

With the existing code, it can detect a directory named `phantomjs` as the phantomjs executable. This was exactly what was happening in my case: Sencha Cmd tool creates a "phantomjs" directory which is reachable from the path, and this was making guard-jasmine fail.
