### PR TITLE
Lock RSpec version to 2.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'jasmine'
 gem 'guard-coffeescript'
 gem 'guard-shell'
 gem 'guard-rspec'
-gem 'rspec'
+gem 'rspec', '~> 2.14.1'
 gem 'tilt'
 
 unless ENV['TRAVIS']


### PR DESCRIPTION
When starting development with the guard-jasmine gem,
the tests are failing because RSpec 3 gets installed, and the old RSpec
syntax (should, stub, etc) is being used in the tests.

This commit locks RSpec to 2.14 and can be removed whenever the upgrade
to RSpec 3 happens.
