### PR TITLE
require 'guard' in jasmine/cli

### DIFF
--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -1,4 +1,5 @@
 require 'thor'
+require 'guard'
 require 'guard/jasmine/version'
 require 'guard/jasmine/runner'
 require 'guard/jasmine/formatter'


### PR DESCRIPTION
Hi,

Jasmine CLI targets fail with the following:

``` shell
.bundle/gems/guard-jasmine-2.0.1/lib/guard/jasmine/cli.rb:242:in `version': uninitialized constant Guard::UI (NameError)
```

In 1.x versions we had a `require guard/ui`, however it doesn't work on its own now.
