### PR TITLE
Update guard compat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,11 @@ group :development do
   gem 'redcarpet'
   gem 'yajl-ruby'
   gem 'rubocop', github: 'bbatsov/rubocop', branch: 'master'
-  gem 'guard-coffeescript', github: 'guard/guard-coffeescript', branch: 'master', require: false
+
+  # Not released yet
+  # gem 'guard-coffeescript', '~> 2.0'
+  gem 'guard-coffeescript', github: 'guard/guard-coffeescript', ref: 'dd6c4f323'
+
   gem 'guard-rspec', require: false
   gem 'guard-shell', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec development_group: :gem_build_tools
 
-unless ENV['TRAVIS']
+group :development do
   gem 'coolline'
   gem 'rb-fsevent'
   gem 'redcarpet'
@@ -11,9 +11,13 @@ unless ENV['TRAVIS']
   gem 'guard-coffeescript', github: 'guard/guard-coffeescript', branch: 'master', require: false
   gem 'guard-rspec', require: false
   gem 'guard-shell', require: false
+
+  gem 'rack'
+  gem 'yard'
 end
 
 group :test, :development do
+  gem 'rake'
   gem 'rspec', '~> 3.1'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,23 @@
 require 'bundler/gem_tasks'
 
 require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec) do |t|
-  t.verbose = false unless ENV.key?('CI')
+
+def ci?
+  ENV['CI'] == 'true'
 end
 
-if ENV['CI'] != 'true'
+default_tasks = []
+
+default_tasks << RSpec::Core::RakeTask.new(:spec) do |t|
+  t.verbose = ci?
+end
+
+unless ci?
   require 'rubocop/rake_task'
-  RuboCop::RakeTask.new(:rubocop)
-  task default: [:spec, :rubocop]
-else
-  task default: [:spec]
+  default_tasks << RuboCop::RakeTask.new(:rubocop)
 end
 
-task default: :spec
+task default: default_tasks.map(&:name)
 
 namespace(:spec) do
   desc 'Run all specs on multiple ruby versions (requires rvm)'

--- a/guard-jasmine.gemspec
+++ b/guard-jasmine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'guard-jasmine'
 
   s.add_dependency 'guard',       '~> 2.8'
-  s.add_dependency('guard-compat', '~> 0.3')
+  s.add_dependency('guard-compat', '~> 1.1')
 
   s.add_dependency 'jasmine',     '~> 2.1'
   s.add_dependency 'multi_json',  '~>1.10'

--- a/guard-jasmine.gemspec
+++ b/guard-jasmine.gemspec
@@ -26,9 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'tilt'
 
   s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rack'
-  s.add_development_dependency 'yard'
 
   s.files        = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md)
   s.executables  = ['guard-jasmine', 'guard-jasmine-debug']

--- a/guard-jasmine.gemspec
+++ b/guard-jasmine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'guard-jasmine'
 
   s.add_dependency 'guard',       '~> 2.8'
-  s.add_dependency('guard-compat', '~> 1.1')
+  s.add_dependency('guard-compat', '~> 1.2')
 
   s.add_dependency 'jasmine',     '~> 2.1'
   s.add_dependency 'multi_json',  '~>1.10'

--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -7,7 +7,7 @@ require 'guard/jasmine/util'
 require 'guard/jasmine/server'
 
 module Guard
-  class Jasmine
+  class Jasmine < Plugin
     # Small helper class to run the Jasmine runner_options once from the
     # command line. This can be useful to integrate guard-jasmine
     # into a continuous integration server.

--- a/lib/guard/jasmine/cli.rb
+++ b/lib/guard/jasmine/cli.rb
@@ -225,7 +225,7 @@ module Guard
         end
 
       rescue => e
-        ::Guard::UI.error "Something went wrong: #{e.message}"
+        Compat::UI.error "Something went wrong: #{e.message}"
         Process.exit 2
       ensure
         ::Guard::Jasmine::Server.stop
@@ -239,7 +239,7 @@ module Guard
       # @see Guard::Jasmine::VERSION
       #
       def version
-        ::Guard::UI.info "Guard::Jasmine version #{ ::Guard::JasmineVersion::VERSION }"
+        Compat::UI.info "Guard::Jasmine version #{ ::Guard::JasmineVersion::VERSION }"
       end
     end
   end

--- a/lib/guard/jasmine/formatter.rb
+++ b/lib/guard/jasmine/formatter.rb
@@ -1,5 +1,7 @@
+require 'guard/compat/plugin'
+
 module Guard
-  class Jasmine
+  class Jasmine < Plugin
     # The Guard::Jasmine formatter collects console and
     # system notification methods and enhances them with
     # some color information.
@@ -71,7 +73,7 @@ module Guard
         # @param [Hash] options the output options
         #
         def suite_name(message, options = {})
-          ::Guard::UI.info(color(message, ';33'), options)
+          Compat::UI.info(color(message, ';33'), options)
         end
 
         # Outputs a system notification.
@@ -93,7 +95,7 @@ module Guard
         # @param [String] color_code the color code
         #
         def color(text, color_code)
-          Compat::UI.send(:color_enabled?) ? "\e[0#{ color_code }m#{ text }\e[0m" : text
+          Compat::UI.color_enabled? ? "\e[0#{ color_code }m#{ text }\e[0m" : text
         end
       end
     end

--- a/lib/guard/jasmine/formatter.rb
+++ b/lib/guard/jasmine/formatter.rb
@@ -13,7 +13,7 @@ module Guard
         # @option options [Boolean] :reset reset the UI
         #
         def info(message, options = {})
-          ::Guard::UI.info(message, options)
+          Compat::UI.info(message, options)
         end
 
         # Print a debug message to the console.
@@ -23,7 +23,7 @@ module Guard
         # @option options [Boolean] :reset reset the UI
         #
         def debug(message, options = {})
-          ::Guard::UI.debug(message, options)
+          Compat::UI.debug(message, options)
         end
 
         # Print a red error message to the console.
@@ -33,7 +33,7 @@ module Guard
         # @option options [Boolean] :reset reset the UI
         #
         def error(message, options = {})
-          ::Guard::UI.error(color(message, ';31'), options)
+          Compat::UI.error(color(message, ';31'), options)
         end
 
         # Print a green success message to the console.
@@ -43,7 +43,7 @@ module Guard
         # @option options [Boolean] :reset reset the UI
         #
         def success(message, options = {})
-          ::Guard::UI.info(color(message, ';32'), options)
+          Compat::UI.info(color(message, ';32'), options)
         end
 
         # Print a yellow pending message to the console.
@@ -53,7 +53,7 @@ module Guard
         # @option options [Boolean] :reset reset the UI
         #
         def spec_pending(message, options = {})
-          ::Guard::UI.info(color(message, ';33'), options)
+          Compat::UI.info(color(message, ';33'), options)
         end
 
         # Print a red spec failed message to the console.
@@ -62,7 +62,7 @@ module Guard
         # @param [Hash] options the output options
         #
         def spec_failed(message, options = {})
-          ::Guard::UI.info(color(message, ';31'), options)
+          Compat::UI.info(color(message, ';31'), options)
         end
 
         # Print a red spec failed message to the console.
@@ -82,7 +82,7 @@ module Guard
         # @option options [String] :title the title of the system notification
         #
         def notify(message, options = {})
-          ::Guard::Notifier.notify(message, options)
+          Compat::UI.notify(message, options)
         end
 
         private
@@ -93,7 +93,7 @@ module Guard
         # @param [String] color_code the color code
         #
         def color(text, color_code)
-          ::Guard::UI.send(:color_enabled?) ? "\e[0#{ color_code }m#{ text }\e[0m" : text
+          Compat::UI.send(:color_enabled?) ? "\e[0#{ color_code }m#{ text }\e[0m" : text
         end
       end
     end

--- a/lib/guard/jasmine/inspector.rb
+++ b/lib/guard/jasmine/inspector.rb
@@ -1,5 +1,7 @@
+require 'guard/compat/plugin'
+
 module Guard
-  class Jasmine
+  class Jasmine < Plugin
     # The inspector verifies if the changed paths are valid
     # for Guard::Jasmine. Please note that request to {.clean}
     # paths keeps the current valid files cached until {.clear} is

--- a/lib/guard/jasmine/runner.rb
+++ b/lib/guard/jasmine/runner.rb
@@ -2,10 +2,13 @@
 
 require 'multi_json'
 require 'fileutils'
+
+require 'guard/compat/plugin'
+require 'guard/jasmine'
 require 'guard/jasmine/util'
 
 module Guard
-  class Jasmine
+  class Jasmine < Plugin
     # The Jasmine runner handles the execution of the spec through the PhantomJS binary,
     # evaluates the JSON response from the PhantomJS Script `guard_jasmine.coffee`,
     # writes the result to the console and triggers optional system notifications.

--- a/lib/guard/jasmine/server.rb
+++ b/lib/guard/jasmine/server.rb
@@ -121,7 +121,7 @@ module Guard
           environment = options[:server_env]
           coverage    = options[:coverage] ? 'on' : 'off'
 
-          ::Guard::UI.info "Guard::Jasmine starts Unicorn spec server on port #{ port } in #{ environment } environment (coverage #{ coverage })."
+          Compat::UI.info "Guard::Jasmine starts Unicorn spec server on port #{ port } in #{ environment } environment (coverage #{ coverage })."
           execute(options, ['unicorn_rails', '-E', environment.to_s, '-p', port.to_s])
         end
 

--- a/lib/guard/jasmine/server.rb
+++ b/lib/guard/jasmine/server.rb
@@ -5,8 +5,10 @@ require 'timeout'
 require 'childprocess'
 require 'jasmine'
 
+require 'guard/compat/plugin'
+
 module Guard
-  class Jasmine
+  class Jasmine < Plugin
     # Start and stop a Jasmine test server for requesting the specs
     # from PhantomJS.
     #
@@ -47,7 +49,7 @@ module Guard
         #
         def stop
           if process
-            ::Guard::UI.info 'Guard::Jasmine stops server.'
+            Compat::UI.info 'Guard::Jasmine stops server.'
             process.stop(5)
           end
         end
@@ -105,7 +107,7 @@ module Guard
           rackup_config = options[:rackup_config]
           coverage      = options[:coverage] ? 'on' : 'off'
 
-          ::Guard::UI.info "Guard::Jasmine starts #{ server } spec server on port #{ port } in #{ environment } environment (coverage #{ coverage })."
+          Compat::UI.info "Guard::Jasmine starts #{ server } spec server on port #{ port } in #{ environment } environment (coverage #{ coverage })."
           execute(options, ['rackup', '-E', environment.to_s, '-p', port.to_s, '-s', server.to_s, rackup_config])
         end
 
@@ -132,7 +134,7 @@ module Guard
         # @option options [Symbol] server the rack server to use
         #
         def start_rake_server(port, task, options)
-          ::Guard::UI.info "Guard::Jasmine starts Jasmine Gem test server on port #{ port }."
+          Compat::UI.info "Guard::Jasmine starts Jasmine Gem test server on port #{ port }."
           execute(options, ['rake', task, "JASMINE_PORT=#{ port }"])
         end
 
@@ -151,8 +153,8 @@ module Guard
           process.io.inherit! if options[:verbose]
           process.start
         rescue => e
-          ::Guard::UI.error "Cannot start server using command #{ cmd.join(' ') }."
-          ::Guard::UI.error "Error was: #{ e.message }"
+          Compat::UI.error "Cannot start server using command #{ cmd.join(' ') }."
+          Compat::UI.error "Error was: #{ e.message }"
         end
 
         # Wait until the Jasmine test server is running.
@@ -174,12 +176,12 @@ module Guard
           end
 
         rescue Timeout::Error
-          ::Guard::UI.warning "Timeout while waiting for the server to startup"
-          ::Guard::UI.warning "Most likely there is a configuration error that's preventing the server from starting"
-          ::Guard::UI.warning "You may need to increase the `:server_timeout` option."
-          ::Guard::UI.warning "The commandline that was used to start the server was:"
-          ::Guard::UI.warning cmd.join(' ')
-          ::Guard::UI.warning "You should attempt to run that and see if any errors occur"
+          Compat::UI.warning "Timeout while waiting for the server to startup"
+          Compat::UI.warning "Most likely there is a configuration error that's preventing the server from starting"
+          Compat::UI.warning "You may need to increase the `:server_timeout` option."
+          Compat::UI.warning "The commandline that was used to start the server was:"
+          Compat::UI.warning cmd.join(' ')
+          Compat::UI.warning "You should attempt to run that and see if any errors occur"
 
           throw :task_has_failed
         end

--- a/lib/guard/jasmine/util.rb
+++ b/lib/guard/jasmine/util.rb
@@ -1,9 +1,10 @@
 require 'net/http'
 require 'timeout'
+require 'guard/compat/plugin'
 require 'guard/jasmine/formatter'
 
 module Guard
-  class Jasmine
+  class Jasmine < Plugin
     # Provider of some shared utility methods.
     #
     module Util

--- a/spec/guard/jasmine/cli_spec.rb
+++ b/spec/guard/jasmine/cli_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Guard::Jasmine::CLI do
 
     context 'with a runner exception' do
       it 'shows the error message' do
-        expect(::Guard::UI).to receive(:error).with('Something went wrong: BANG!')
+        expect(Guard::Compat::UI).to receive(:error).with('Something went wrong: BANG!')
         allow_any_instance_of(runner).to receive(:run).and_raise 'BANG!'
         cli.start(['spec'])
       end
@@ -443,7 +443,7 @@ RSpec.describe Guard::Jasmine::CLI do
 
   describe '.version' do
     it 'outputs the Guard::Jasmine version' do
-      expect(::Guard::UI).to receive(:info).with("Guard::Jasmine version #{ ::Guard::JasmineVersion::VERSION }")
+      expect(Guard::Compat::UI).to receive(:info).with("Guard::Jasmine version #{ ::Guard::JasmineVersion::VERSION }")
       cli.start(['-v'])
     end
   end

--- a/spec/guard/jasmine/cli_spec.rb
+++ b/spec/guard/jasmine/cli_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Guard::Jasmine::CLI do
     allow(cli).to receive(:which).and_return '/usr/local/bin/phantomjs'
     allow(cli).to receive(:phantomjs_bin_valid?).and_return true
     allow(cli).to receive(:runner_available?).and_return true
+
+    allow(Guard::Compat::UI).to receive(:error)
   end
 
   describe '.spec' do

--- a/spec/guard/jasmine/formatter_spec.rb
+++ b/spec/guard/jasmine/formatter_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Guard::Jasmine::Formatter do
   let(:formatter) { Guard::Jasmine::Formatter }
-  let(:ui) { Guard::UI }
-  let(:notifier) { Guard::Notifier }
+  let(:ui) { Guard::Compat::UI }
 
   describe '.info' do
     it 'shows an info message' do
@@ -40,7 +39,7 @@ RSpec.describe Guard::Jasmine::Formatter do
 
   describe '.notify' do
     it 'shows an info message' do
-      expect(notifier).to receive(:notify).with('Notify message',  image: :failed)
+      expect(ui).to receive(:notify).with('Notify message',  image: :failed)
       formatter.notify('Notify message',  image: :failed)
     end
   end

--- a/spec/guard/jasmine/formatter_spec.rb
+++ b/spec/guard/jasmine/formatter_spec.rb
@@ -1,6 +1,16 @@
+require 'guard/jasmine/formatter'
+
 RSpec.describe Guard::Jasmine::Formatter do
   let(:formatter) { Guard::Jasmine::Formatter }
+
   let(:ui) { Guard::Compat::UI }
+  before do
+    allow(ui).to receive(:info)
+    allow(ui).to receive(:debug)
+    allow(ui).to receive(:error)
+    allow(ui).to receive(:warning)
+    allow(ui).to receive(:color_enabled?).and_return(true)
+  end
 
   describe '.info' do
     it 'shows an info message' do

--- a/spec/guard/jasmine/inspector_spec.rb
+++ b/spec/guard/jasmine/inspector_spec.rb
@@ -1,3 +1,5 @@
+require 'guard/jasmine/inspector'
+
 RSpec.describe Guard::Jasmine::Inspector do
   before do
     allow(File).to receive(:exist?) do |file|

--- a/spec/guard/jasmine/runner_spec.rb
+++ b/spec/guard/jasmine/runner_spec.rb
@@ -6,6 +6,8 @@ def read_fixture(name)
   Pathname.new(__FILE__).dirname.join('fixtures', name + '.json').read
 end
 
+require 'guard/jasmine/runner'
+
 RSpec.describe Guard::Jasmine::Runner do
   let(:formatter) { Guard::Jasmine::Formatter }
 

--- a/spec/guard/jasmine/runner_spec.rb
+++ b/spec/guard/jasmine/runner_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe Guard::Jasmine::Runner do
 
     allow(runner).to receive(:`) # `
     allow(runner).to receive(:update_coverage)
+
+    allow(Guard::Compat::UI).to receive(:color_enabled?).and_return(true)
+    allow(Guard::Compat::UI).to receive(:info)
   end
 
   describe '#run' do

--- a/spec/guard/jasmine/server_spec.rb
+++ b/spec/guard/jasmine/server_spec.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+require 'guard/jasmine/server'
+
 RSpec.describe Guard::Jasmine::Server do
   let(:server) { Guard::Jasmine::Server }
 

--- a/spec/guard/jasmine/server_spec.rb
+++ b/spec/guard/jasmine/server_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Guard::Jasmine::Server do
     allow(server).to receive(:start_rack_server)
     allow(server).to receive(:start_rake_server)
     allow(server).to receive(:wait_for_server)
+
+    allow(Guard::Compat::UI).to receive(:info)
   end
 
   describe '.start' do

--- a/spec/guard/jasmine/util_spec.rb
+++ b/spec/guard/jasmine/util_spec.rb
@@ -1,3 +1,5 @@
+require 'guard/jasmine'
+
 RSpec.describe Guard::Jasmine::Util do
   let(:util) { Class.new { extend Guard::Jasmine::Util } }
 

--- a/spec/guard/jasmine/util_spec.rb
+++ b/spec/guard/jasmine/util_spec.rb
@@ -3,6 +3,10 @@ require 'guard/jasmine'
 RSpec.describe Guard::Jasmine::Util do
   let(:util) { Class.new { extend Guard::Jasmine::Util } }
 
+  before do
+    allow(Guard::Compat::UI).to receive(:info)
+  end
+
   describe '.runner_available?' do
     let(:http) do
       double('http').tap do |http|

--- a/spec/guard/jasmine/version_spec.rb
+++ b/spec/guard/jasmine/version_spec.rb
@@ -1,3 +1,5 @@
+require 'guard/jasmine/version'
+
 RSpec.describe Guard::JasmineVersion do
   describe 'VERSION' do
     it 'defines the version' do

--- a/spec/guard/jasmine_spec.rb
+++ b/spec/guard/jasmine_spec.rb
@@ -1,3 +1,6 @@
+require 'guard/compat/test/helper'
+require 'guard/jasmine'
+
 RSpec.describe Guard::Jasmine do
   let(:guard) { Guard::Jasmine.new }
 
@@ -8,7 +11,15 @@ RSpec.describe Guard::Jasmine do
 
   let(:defaults) { Guard::Jasmine::DEFAULT_OPTIONS }
 
+  let(:ui) { Guard::Compat::UI }
+
   before do
+    allow(ui).to receive(:info)
+    allow(ui).to receive(:debug)
+    allow(ui).to receive(:error)
+    allow(ui).to receive(:warning)
+    allow(ui).to receive(:color_enabled?).and_return(true)
+
     allow(inspector).to receive(:clean) { |specs, _options| specs }
     allow(guard.runner).to receive(:run).and_return({})
     allow(formatter).to receive(:notify)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,11 +28,11 @@ RSpec.configure do |config|
     ENV['GUARD_ENV'] = 'test'
     @project_path    = Pathname.new(File.expand_path('../../', __FILE__))
 
-    allow(Guard::UI).to receive(:info)
-    allow(Guard::UI).to receive(:debug)
-    allow(Guard::UI).to receive(:error)
-    allow(Guard::UI).to receive(:warning)
-    allow(Guard::UI).to receive(:color_enabled?).and_return(true)
+    allow(Guard::Compat::UI).to receive(:info)
+    allow(Guard::Compat::UI).to receive(:debug)
+    allow(Guard::Compat::UI).to receive(:error)
+    allow(Guard::Compat::UI).to receive(:warning)
+    allow(Guard::Compat::UI).to receive(:color_enabled?).and_return(true)
   end
 
   config.after(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
 require 'rspec'
 
-require 'guard/compat/test/helper'
-require 'guard/jasmine'
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -25,17 +22,6 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
 
   config.before(:each) do
-    ENV['GUARD_ENV'] = 'test'
     @project_path    = Pathname.new(File.expand_path('../../', __FILE__))
-
-    allow(Guard::Compat::UI).to receive(:info)
-    allow(Guard::Compat::UI).to receive(:debug)
-    allow(Guard::Compat::UI).to receive(:error)
-    allow(Guard::Compat::UI).to receive(:warning)
-    allow(Guard::Compat::UI).to receive(:color_enabled?).and_return(true)
-  end
-
-  config.after(:each) do
-    ENV['GUARD_ENV'] = nil
   end
 end


### PR DESCRIPTION
With this guard-jasmine should be "protected" from upcoming major Guard refactoring.

- uses Guard::Compat API (except for Jasmine Server)
- tested on guard-jasmine-rails-test
- development: same changes as guard-coffeescript 2.0 will have (once I get gem access)

Let me know if you have any issues/requests with this PR or with Guard or Guard::Compat.

I'm pretty much done with Guard::Compat and updating all the plugins, so if there's anything useful missing from the Compat API, let me know (open an issue in Guard::Compat).