### PR TITLE
Remove phantomjs warnings before parsing json

### DIFF
--- a/lib/guard/jasmine/runner.rb
+++ b/lib/guard/jasmine/runner.rb
@@ -229,6 +229,7 @@ module Guard
       def evaluate_response(output, file)
         json = output.read
         json = json.encode('UTF-8') if json.respond_to?(:encode)
+        json = json.gsub(/Unsafe JavaScript.*/, '')
         begin
           result = MultiJson.decode(json,  max_nesting: false)
           fail 'No response from Jasmine runner' if !result && options[:is_cli]

--- a/spec/guard/jasmine/fixtures/failure.json
+++ b/spec/guard/jasmine/fixtures/failure.json
@@ -72,3 +72,4 @@
     }
   ]
 }
+Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL file:///phantom-script.js. Domains, protocols and ports must match.


### PR DESCRIPTION
While using guard-jasmine to run my tests, I noticed that phantom was printing not only the JSON output, but also content warnings. This commit removes content warnings from the phantomjs output before parsing it as JSON.