### PR TITLE
Support Rails 4.2 / Sprockets 3+

### DIFF
--- a/lib/guard/jasmine/coverage.rb
+++ b/lib/guard/jasmine/coverage.rb
@@ -60,7 +60,9 @@ if ENV['COVERAGE'] == 'true' && defined?(Rails)
   #
   class GuardJasmineCoverageEngine < ::Rails::Engine
     initializer 'guard-jasmine.initialize' do |app|
-      app.assets.register_postprocessor 'application/javascript', JasmineCoverage
+      app.config.assets.configure do |env|
+        env.register_postprocessor 'application/javascript', JasmineCoverage
+      end
     end
   end
 


### PR DESCRIPTION
Fixes `undefined method 'register_postprocessor' for nil:NilClass` when using guard-jasmine with Rails 4.2+